### PR TITLE
Support images hosted via gh-pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
     <div class="wrapper">
       <header>
         <div class="header-section">
-          <img src="/assets/logo.svg" alt="Daily logo" />
+          <img src="assets/logo.svg" alt="Daily logo" />
           <span class="title">Web Components demo</span>
         </div>
         <div class="header-section">
@@ -24,7 +24,7 @@
             rel="noreferrer noopenner"
           >
             <span>API docs</span>
-            <img src="/assets/newtab.svg" alt="New tab" />
+            <img src="assets/newtab.svg" alt="New tab" />
           </a>
           <a
             class="github-link"
@@ -32,7 +32,7 @@
             target="_blank"
             rel="noreferrer noopenner"
           >
-            <img src="/assets/github.svg" alt="Github" />
+            <img src="assets/github.svg" alt="Github" />
           </a>
         </div>
       </header>


### PR DESCRIPTION
Just a tiny tweak after testing the live GitHub-hosted demo link -- GitHub Pages struggles with paths, this super-relative path works locally and in the hosted demo.